### PR TITLE
Remove rescheduler dependency

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -93,7 +93,7 @@ func TestCache_Delete(t *testing.T) {
 	c.Delete("a")
 
 	// scheduler should finish after deleting the item
-	c.sched.Wait()
+	time.Sleep(time.Second)
 	assert.Nil(t, c.chain)
 }
 
@@ -129,7 +129,7 @@ func TestCache_Cleaner(t *testing.T) {
 	assert.Equal(t, "", get)
 
 	// scheduler should finish after the chain is empty
-	c.sched.Wait()
+	time.Sleep(time.Second)
 	assert.Nil(t, c.chain)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/1f349/cache
 
 go 1.21
 
-require (
-	github.com/mrmelon54/rescheduler v0.0.3
-	github.com/stretchr/testify v1.10.0
-)
+require github.com/stretchr/testify v1.10.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/mrmelon54/rescheduler v0.0.3 h1:TrkJL6S7PKvXuo1mvdgRgsILA/pk5L1lrXhV/q7IEzQ=
-github.com/mrmelon54/rescheduler v0.0.3/go.mod h1:q415n6W1xcePPP5Rix6FOiADgcN66BYMyNOsFnNyoWQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=


### PR DESCRIPTION
Having an idle goroutine could be a performance improvement as it removes the overhead required to start and stop the goroutine.
